### PR TITLE
Adds auto-scaling-group schedule options input vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.0.5
+
+**Commit Delta**: [Change from 0.0.4 release](https://github.com/plus3it/terraform-aws-vault/compare/0.0.4...0.0.5)
+
+**Released**: 2019.11.04
+
+**Summary**:
+
+* Added input vars `scale_up_schedule` and `scale_down_schedule` to control AutoScaling Group Scheduled Action option. 
+
 ### 0.0.4
 
 **Commit Delta**: [Change from 0.0.3 release](https://github.com/plus3it/terraform-aws-vault/compare/0.0.3...0.0.4)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ sync_policies:
 | point\_in\_time\_recovery | (Optional) Enabling Amazon DynamoDB point-in-time recovery (PITR) provides automatic backups of your DynamoDB table data. | bool | `"true"` | no |
 | pypi\_index\_url | (Optional) URL to the PyPi Index | string | `"https://pypi.org/simple"` | no |
 | route53\_zone\_id | Hosted zone ID Route 53 hosted zone | string | n/a | yes |
+| scale\_down\_schedule | (Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. "0 0 * * *") | string | `"null"` | no |
+| scale\_up\_schedule | (Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. "0 10 * * Mon-Fri") | string | `"null"` | no |
 | tags | (Optional) List of tags to include with resource | map(string) | `<map>` | no |
 | toggle\_update | (Optional) Toggle that triggers a stack update by modifying the launch config, resulting in new instances; must be one of: A or B | string | `"A"` | no |
 | vault\_pillar\_extra\_config | (Optional) List extra configurations to be referenced in the pillar | object | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -453,9 +453,11 @@ module "autoscaling_group" {
   WatchmakerAdminUsers  = var.watchmaker_admin_users
   WatchmakerOuPath      = var.watchmaker_ou_path
 
-  DesiredCapacity = var.desired_capacity
-  MinCapacity     = var.min_capacity
-  MaxCapacity     = var.max_capacity
+  DesiredCapacity   = var.desired_capacity
+  MinCapacity       = var.min_capacity
+  MaxCapacity       = var.max_capacity
+  ScaleDownSchedule = var.scale_down_schedule
+  ScaleUpSchedule   = var.scale_up_schedule
 
   EnableRepos = local.enabled_repos
 }

--- a/tests/vault-py2/main.tf
+++ b/tests/vault-py2/main.tf
@@ -26,6 +26,9 @@ module "base" {
   route53_zone_id = var.route53_zone_id
   certificate_arn = var.certificate_arn
 
+  scale_up_schedule   = var.scale_up_schedule
+  scale_down_schedule = var.scale_down_schedule
+
   # Vault settings
   vault_version             = var.vault_version
   vault_pillar_path         = var.vault_pillar_path

--- a/tests/vault-py2/variables.tf
+++ b/tests/vault-py2/variables.tf
@@ -85,3 +85,14 @@ variable "vault_pillar_extra_config" {
   default     = []
 }
 
+variable "scale_down_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")"
+  default     = null
+}
+
+variable "scale_up_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")"
+  default     = null
+}

--- a/tests/vault-py3/main.tf
+++ b/tests/vault-py3/main.tf
@@ -23,6 +23,9 @@ module "vault-py3" {
   cloudwatch_agent_url         = var.cloudwatch_agent_url
   ec2_extra_security_group_ids = var.ec2_extra_security_group_ids
 
+  scale_up_schedule   = var.scale_up_schedule
+  scale_down_schedule = var.scale_down_schedule
+
   domain_name     = var.domain_name
   route53_zone_id = var.route53_zone_id
   certificate_arn = var.certificate_arn

--- a/tests/vault-py3/variables.tf
+++ b/tests/vault-py3/variables.tf
@@ -84,3 +84,15 @@ variable "vault_pillar_extra_config" {
   description = "(Optional) List extra configurations to be referenced in the pillar"
   default     = []
 }
+
+variable "scale_down_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")"
+  default     = null
+}
+
+variable "scale_up_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,18 @@ variable "desired_capacity" {
   default     = "2"
 }
 
+variable "scale_down_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")"
+  default     = null
+}
+
+variable "scale_up_schedule" {
+  type        = string
+  description = "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")"
+  default     = null
+}
+
 variable "dynamodb_max_read_capacity" {
   type        = number
   description = "(Optional) The max capacity of the scalable target for DynamoDb table autoscaling."


### PR DESCRIPTION
Scheduled Action is already part of the `terraform-aws-watchmaker` module. 
This PR just updates `terraform-aws-vault` to accept the input vars and pass them along.