### PR TITLE
Fixes bug where slashes are removed from the vault paths

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.0.6
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.0.6
+
+**Commit Delta**: [Change from 0.0.5 release](https://github.com/plus3it/terraform-aws-vault/compare/0.0.5...0.0.6)
+
+**Released**: 2019.11.14
+
+**Summary**:
+
+* Fixed bug [#10](https://github.com/plus3it/terraform-aws-vault/issues/10) addressing forward slashes are being removed from `path`.
+* Changed `changes` output for the the `synced` salt state modules.
+  
 ### 0.0.5
 
 **Commit Delta**: [Change from 0.0.4 release](https://github.com/plus3it/terraform-aws-vault/compare/0.0.4...0.0.5)


### PR DESCRIPTION
This patch fixes the bug #10  where slashes in the path are being removed. Also, did some cleaning up to the changes result of the salt `vault.synced` states:

An example of the new change results:
```yaml
 Function: vault.secret_engines_synced
      Result: True
     Comment: 
     Started: 21:46:55.872968
    Duration: 30.755 ms
     Changes:   
              ----------
              new:
                  ----------
                  cubbyhole/:
                      ----------
                      accessor:
                          cubbyhole_628b625a
                      config:
                          ----------
                          default_lease_ttl:
                              0
                          force_no_cache:
                              False
                          max_lease_ttl:
                              0
                      description:
                          per-token private secret storage
                      local:
                          True
                      options:
                          None
                      seal_wrap:
                          False
                      type:
                          cubbyhole
                      uuid:
                          8460db26-1c1e-74b4-ff72-e509c13e9c9d
```